### PR TITLE
Add docsite with PoC documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # Batch-on-Kafka
-Batch on Kafka
+
+This repository contains a proof of concept for batch ingestion backed by **Redpanda** and **ClickHouse**. Uploads are sent through a FastAPI service, written to Redpanda, validated by a worker, and stored in ClickHouse.
+
+See [docsite](./docsite) for detailed API and schema information.

--- a/docsite/clickhouse.md
+++ b/docsite/clickhouse.md
@@ -1,0 +1,27 @@
+# ClickHouse Tables
+
+Validated rows are stored in ClickHouse for analytical queries.
+
+```sql
+-- Example per-model table
+CREATE TABLE data_<model_id> (
+    event_id String,
+    timestamp UInt32,
+    -- additional attributes depending on the model schema
+) ENGINE = MergeTree
+ORDER BY (event_id);
+
+-- Rejected rows across all jobs
+CREATE TABLE rejected_rows (
+    job_id String,
+    row UInt32,
+    event_id String,
+    column String,
+    type String,
+    error String,
+    observed String,
+    message String,
+    ts DateTime DEFAULT now()
+) ENGINE = MergeTree
+ORDER BY (job_id, row);
+```

--- a/docsite/index.md
+++ b/docsite/index.md
@@ -1,0 +1,12 @@
+# Batch Ingestion Proof of Concept
+
+This documentation describes the PoC for batching data into analytics storage using Kafka-compatible Redpanda and ClickHouse.
+
+## Overview
+
+- **Redpanda** provides the Kafka API broker used for job data and model metadata.
+- **ClickHouse** stores validated rows and rejected rows for analytical queries.
+- The API service accepts file uploads and streams rows to Redpanda.
+- A background worker consumes each job's topic, validates rows against the registered model schema, and inserts good rows into ClickHouse.
+
+See the other pages in this documentation for REST API details, Kafka topics, and message schemas.

--- a/docsite/kafka-topics.md
+++ b/docsite/kafka-topics.md
@@ -1,0 +1,11 @@
+# Kafka Topics
+
+The system uses Redpanda as the Kafka broker. Topics are created dynamically per job and retain data for a limited time.
+
+| Purpose | Name | Partitions | Cleanup | Retention |
+|---------|------|-----------|---------|-----------|
+| Job metadata | `batch.jobs` | 3 | compact | infinite |
+| Per-job data | `/batch/<job_id>` | 6 | delete | 1 day (configurable via `RETENTION_HOURS`) |
+| Per-job dead-letter | `/batch/<job_id>/dql` | 6 | delete | 1 day (same as above) |
+
+A compacted topic `batch.models` stores model schemas so both services can reload them on startup.

--- a/docsite/rest-api.md
+++ b/docsite/rest-api.md
@@ -1,0 +1,17 @@
+# REST API
+
+All endpoints return JSON. Success is indicated by 2xx codes; non-2xx codes contain an error description.
+
+| Method | Path | Purpose | Success Code |
+|-------|------|---------|--------------|
+| `GET` | `/models` | List models | `200` |
+| `POST` | `/models` | Create model. Body: `{\"name\":...,\"schema\":...}` | `201` |
+| `PUT` | `/models/{id}` | Update schema | `200` |
+| `DELETE` | `/models/{id}` | Delete model | `204` |
+| `POST` | `/jobs` | Multipart upload with `model_id` and file | `202` (returns `{job_id}`) |
+| `GET` | `/jobs` | List jobs | `200` |
+| `GET` | `/jobs/{id}` | Job status | `200` |
+| `DELETE` | `/jobs/{id}` | Cancel job | `202` |
+| `GET` | `/jobs/{id}/rejected` | Stream rejected rows (CSV) | `200` |
+
+Uploads must be `.csv` or `.parquet`. Files larger than 1&nbsp;GB are rejected.

--- a/docsite/schemas.md
+++ b/docsite/schemas.md
@@ -1,0 +1,31 @@
+# Message Schemas
+
+## Job Status (`batch.jobs`)
+```json
+{
+  "job_id": "a1b2c3d4",
+  "model_id": "fraud_detector",
+  "state": "RUNNING|SUCCESS|PARTIAL_SUCCESS|FAILED|PENDING|CANCELLED",
+  "totals": {"rows": 50000, "ok": 30500, "errors": 12},
+  "timings": {"waiting_ms": 2100, "processing_ms": 40000},
+  "updated_at": "2025-05-18T15:05:07Z"
+}
+```
+
+## Data Row (`/batch/<job_id>`)
+```json
+{"offset": 0, "payload": "<raw-csv-or-parquet-row-as-bytes>"}
+```
+
+## Dead-Letter Row (`/batch/<job_id>/dql`)
+```json
+{
+  "row": 1,
+  "event_id": "1003cdef",
+  "column": "timestamp",
+  "type": "TIMESTAMP",
+  "error": "INVALID_TIMESTAMP",
+  "observed": "\"yesterday\"",
+  "message": "The 'timestamp' value is invalid..."
+}
+```


### PR DESCRIPTION
## Summary
- document the PoC architecture in `docsite`
- add pages for REST API, Kafka topics, schemas, and ClickHouse tables
- mention Redpanda and ClickHouse in the repository README

## Testing
- `pytest -q` *(fails: command not found)*
- `make test` *(fails: no rule)*