### PR TITLE
Implement minimal batch ingestion components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "batch.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -3,3 +3,20 @@
 This repository contains a proof of concept for batch ingestion backed by **Redpanda** and **ClickHouse**. Uploads are sent through a FastAPI service, written to Redpanda, validated by a worker, and stored in ClickHouse.
 
 See [docsite](./docsite) for detailed API and schema information.
+
+## Local Development
+
+Build and start the stack using Docker Compose:
+
+```bash
+docker-compose up --build
+```
+
+The API will be available at `http://localhost:8000` and Redpanda at `localhost:9092`.
+Use the CLI via `python -m batch.cli`.
+Set `BATCH_API_URL` and `KAFKA_BOOTSTRAP` if running the services elsewhere:
+
+```bash
+export BATCH_API_URL=http://localhost:8000
+export KAFKA_BOOTSTRAP=localhost:9092
+```

--- a/batch/api.py
+++ b/batch/api.py
@@ -1,0 +1,161 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException, status
+from fastapi.responses import JSONResponse, StreamingResponse
+from uuid import uuid4
+import os
+import csv
+import asyncio
+from typing import Dict, Any, Optional
+
+import pyarrow.parquet as pq
+from aiokafka import AIOKafkaProducer
+
+app = FastAPI()
+
+MODELS: Dict[str, Dict[str, Any]] = {}
+JOBS: Dict[str, Dict[str, Any]] = {}
+MAX_FILE_SIZE = 1 * 1024 * 1024 * 1024  # 1GB
+KAFKA_BOOTSTRAP = os.environ.get("KAFKA_BOOTSTRAP", "redpanda:9092")
+_producer: Optional[AIOKafkaProducer] = None
+
+
+async def get_producer() -> AIOKafkaProducer:
+    global _producer
+    if _producer is None:
+        _producer = AIOKafkaProducer(bootstrap_servers=KAFKA_BOOTSTRAP)
+    while True:
+        try:
+            await _producer.start()
+            break
+        except Exception as exc:
+            # keep retrying until Redpanda is available
+            print(f"Producer connect failed: {exc}. Retrying...")
+            await asyncio.sleep(5)
+    return _producer
+
+
+def _peek_validate(file_path: str, ext: str):
+    """Peek into the file to ensure it's a valid CSV or Parquet."""
+    if ext == ".csv":
+        with open(file_path, "rb") as f:
+            head = f.read(1024)
+        try:
+            head.decode("utf-8")
+        except UnicodeDecodeError as e:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, detail=f"Invalid CSV encoding: {e}"
+            )
+        try:
+            sample = head.decode("utf-8").splitlines()[0]
+            csv.reader([sample])
+        except Exception as e:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, detail=f"Invalid CSV content: {e}"
+            )
+    elif ext == ".parquet":
+        try:
+            pq.ParquetFile(file_path)
+        except Exception as e:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, detail=f"Invalid Parquet file: {e}"
+            )
+    else:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Unsupported file type")
+
+
+@app.get("/models")
+def list_models():
+    return list(MODELS.values())
+
+
+@app.post("/models", status_code=status.HTTP_201_CREATED)
+def create_model(model: Dict[str, Any]):
+    model_id = uuid4().hex[:8]
+    MODELS[model_id] = {"id": model_id, **model}
+    return MODELS[model_id]
+
+
+@app.put("/models/{model_id}")
+def update_model(model_id: str, model: Dict[str, Any]):
+    if model_id not in MODELS:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Model not found")
+    MODELS[model_id].update(model)
+    return MODELS[model_id]
+
+
+@app.delete("/models/{model_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_model(model_id: str):
+    if MODELS.pop(model_id, None) is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Model not found")
+    return JSONResponse(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@app.post("/jobs", status_code=status.HTTP_202_ACCEPTED)
+async def create_job(model_id: str, file: UploadFile = File(...)):
+    if model_id not in MODELS:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Model not found")
+
+    ext = os.path.splitext(file.filename)[1].lower()
+    if ext not in {".csv", ".parquet"}:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST, detail="File must be CSV or Parquet"
+        )
+
+    contents = await file.read()
+    if len(contents) > MAX_FILE_SIZE:
+        raise HTTPException(
+            status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, detail="File exceeds 1GB limit"
+        )
+
+    tmp_path = f"/tmp/{uuid4().hex}{ext}"
+    with open(tmp_path, "wb") as f:
+        f.write(contents)
+
+    _peek_validate(tmp_path, ext)
+
+    producer = await get_producer()
+    job_id = uuid4().hex[:8]
+    topic = f"/batch/{job_id}"
+    await producer.send_and_wait(topic, contents)
+    os.remove(tmp_path)
+
+    JOBS[job_id] = {
+        "id": job_id,
+        "model_id": model_id,
+        "state": "PENDING",
+        "totals": {"rows": 0, "ok": 0, "errors": 0},
+    }
+    return {"job_id": job_id}
+
+
+@app.get("/jobs")
+def list_jobs():
+    return list(JOBS.values())
+
+
+@app.get("/jobs/{job_id}")
+def job_status(job_id: str):
+    job = JOBS.get(job_id)
+    if not job:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Job not found")
+    return job
+
+
+@app.delete("/jobs/{job_id}", status_code=status.HTTP_202_ACCEPTED)
+def cancel_job(job_id: str):
+    job = JOBS.get(job_id)
+    if not job:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Job not found")
+    job["state"] = "CANCELLED"
+    return {"detail": f"job {job_id} cancelled"}
+
+
+@app.get("/jobs/{job_id}/rejected")
+def rejected_rows(job_id: str):
+    job = JOBS.get(job_id)
+    if not job:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Job not found")
+
+    async def iterator():
+        yield "ROW,EVENT_ID,COLUMN,TYPE,ERROR,OBSERVED,MESSAGE\n"
+
+    return StreamingResponse(iterator(), media_type="text/csv")

--- a/batch/cli.py
+++ b/batch/cli.py
@@ -1,0 +1,81 @@
+import os
+import typer
+import requests
+
+API_URL = os.environ.get("BATCH_API_URL", "http://localhost:8000")
+
+app = typer.Typer()
+model_app = typer.Typer(name="model")
+job_app = typer.Typer(name="job")
+app.add_typer(model_app)
+app.add_typer(job_app)
+
+
+@model_app.command("list")
+def model_list():
+    r = requests.get(f"{API_URL}/models")
+    typer.echo(r.json())
+
+
+@model_app.command("describe")
+def model_describe(model_id: str):
+    r = requests.get(f"{API_URL}/models/{model_id}")
+    typer.echo(r.json())
+
+
+@model_app.command("create")
+def model_create(name: str, schema: str):
+    with open(schema) as f:
+        schema_data = f.read()
+    r = requests.post(f"{API_URL}/models", json={"name": name, "schema": schema_data})
+    typer.echo(r.json())
+
+
+@model_app.command("update")
+def model_update(model_id: str, schema: str):
+    with open(schema) as f:
+        schema_data = f.read()
+    r = requests.put(f"{API_URL}/models/{model_id}", json={"schema": schema_data})
+    typer.echo(r.json())
+
+
+@model_app.command("delete")
+def model_delete(model_id: str):
+    r = requests.delete(f"{API_URL}/models/{model_id}")
+    typer.echo(r.status_code)
+
+
+@job_app.command("list")
+def job_list():
+    r = requests.get(f"{API_URL}/jobs")
+    typer.echo(r.json())
+
+
+@job_app.command("create")
+def job_create(model_id: str, data_file: str):
+    with open(data_file, "rb") as f:
+        files = {"file": (os.path.basename(data_file), f)}
+        r = requests.post(f"{API_URL}/jobs", params={"model_id": model_id}, files=files)
+    typer.echo(r.json())
+
+
+@job_app.command("status")
+def job_status(job_id: str):
+    r = requests.get(f"{API_URL}/jobs/{job_id}")
+    typer.echo(r.json())
+
+
+@job_app.command("cancel")
+def job_cancel(job_id: str):
+    r = requests.delete(f"{API_URL}/jobs/{job_id}")
+    typer.echo(r.json())
+
+
+@job_app.command("rejected")
+def job_rejected(job_id: str):
+    r = requests.get(f"{API_URL}/jobs/{job_id}/rejected")
+    typer.echo(r.text)
+
+
+if __name__ == "__main__":
+    app()

--- a/batch/worker.py
+++ b/batch/worker.py
@@ -1,0 +1,47 @@
+import asyncio
+import logging
+import os
+from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+KAFKA_BOOTSTRAP = os.environ.get("KAFKA_BOOTSTRAP", "redpanda:9092")
+
+
+async def _start(client):
+    while True:
+        try:
+            await client.start()
+            break
+        except Exception as exc:
+            logger.warning("Kafka connect failed: %s. Retrying...", exc)
+            await asyncio.sleep(5)
+
+
+async def consume(job_id: str):
+    topic = f"/batch/{job_id}"
+    dql_topic = f"/batch/{job_id}/dql"
+    consumer = AIOKafkaConsumer(topic, bootstrap_servers=KAFKA_BOOTSTRAP)
+    producer = AIOKafkaProducer(bootstrap_servers=KAFKA_BOOTSTRAP)
+    await _start(consumer)
+    await _start(producer)
+
+    try:
+        async for msg in consumer:
+            try:
+                logger.info("Got message from %s offset %s", topic, msg.offset)
+            except Exception as exc:
+                logger.error("Processing failed: %s", exc)
+                await producer.send_and_wait(dql_topic, msg.value)
+    finally:
+        await consumer.stop()
+        await producer.stop()
+
+
+def main(job_id: str = "testjob"):
+    asyncio.run(consume(job_id))
+
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.9'
+services:
+  redpanda:
+    image: docker.redpanda.com/redpanda/redpanda:latest
+    command: ["redpanda", "start", "--smp", "1", "--reserve-memory", "0M", "--overprovisioned"]
+    ports:
+      - "9092:9092"
+  api:
+    build: .
+    volumes:
+      - .:/app
+    environment:
+      - BATCH_API_URL=http://api:8000
+      - KAFKA_BOOTSTRAP=redpanda:9092
+    ports:
+      - "8000:8000"
+    depends_on:
+      - redpanda
+  worker:
+    build: .
+    command: python -m batch.worker
+    depends_on:
+      - redpanda
+    environment:
+      - BATCH_API_URL=http://api:8000
+      - KAFKA_BOOTSTRAP=redpanda:9092

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+aiokafka
+typer
+requests
+pyarrow


### PR DESCRIPTION
## Summary
- add FastAPI service with CSV/Parquet validation and file size checks
- provide CLI using Typer for model and job commands
- implement worker that keeps retrying connection to Redpanda
- create Dockerfile and docker-compose stack for local dev
- document docker compose usage
- improve kafka connectivity and config

## Testing
- `python -m compileall -q batch`
- `black batch/*.py`
