### PR TITLE
Add logging and validation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,13 @@ Set `BATCH_API_URL` and `KAFKA_BOOTSTRAP` if running the services elsewhere:
 export BATCH_API_URL=http://localhost:8000
 export KAFKA_BOOTSTRAP=localhost:9092
 ```
+
+### Linting and Tests
+
+Install development dependencies and run the linter and test suite:
+
+```bash
+pip install ruff pytest
+ruff batch tests
+pytest
+```

--- a/batch/worker.py
+++ b/batch/worker.py
@@ -21,7 +21,7 @@ async def _start(client):
 
 async def consume(job_id: str):
     topic = f"/batch/{job_id}"
-    dql_topic = f"/batch/{job_id}/dql"
+    dlq_topic = f"/batch/{job_id}/dlq"
     consumer = AIOKafkaConsumer(topic, bootstrap_servers=KAFKA_BOOTSTRAP)
     producer = AIOKafkaProducer(bootstrap_servers=KAFKA_BOOTSTRAP)
     await _start(consumer)
@@ -33,7 +33,7 @@ async def consume(job_id: str):
                 logger.info("Got message from %s offset %s", topic, msg.offset)
             except Exception as exc:
                 logger.error("Processing failed: %s", exc)
-                await producer.send_and_wait(dql_topic, msg.value)
+                await producer.send_and_wait(dlq_topic, msg.value)
     finally:
         await consumer.stop()
         await producer.stop()

--- a/docsite/kafka-topics.md
+++ b/docsite/kafka-topics.md
@@ -6,6 +6,6 @@ The system uses Redpanda as the Kafka broker. Topics are created dynamically per
 |---------|------|-----------|---------|-----------|
 | Job metadata | `batch.jobs` | 3 | compact | infinite |
 | Per-job data | `/batch/<job_id>` | 6 | delete | 1 day (configurable via `RETENTION_HOURS`) |
-| Per-job dead-letter | `/batch/<job_id>/dql` | 6 | delete | 1 day (same as above) |
+| Per-job dead-letter | `/batch/<job_id>/dlq` | 6 | delete | 1 day (same as above) |
 
 A compacted topic `batch.models` stores model schemas so both services can reload them on startup.

--- a/docsite/schemas.md
+++ b/docsite/schemas.md
@@ -17,7 +17,7 @@
 {"offset": 0, "payload": "<raw-csv-or-parquet-row-as-bytes>"}
 ```
 
-## Dead-Letter Row (`/batch/<job_id>/dql`)
+## Dead-Letter Row (`/batch/<job_id>/dlq`)
 ```json
 {
   "row": 1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.ruff]
+line-length = 100
+

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,40 @@
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from fastapi import HTTPException
+
+from batch.api import _peek_validate
+
+
+def test_valid_csv(tmp_path):
+    p = tmp_path / "data.csv"
+    p.write_text("col\n1")
+    _peek_validate(str(p), ".csv")
+
+
+def test_invalid_csv(tmp_path):
+    p = tmp_path / "bad.csv"
+    p.write_bytes(b"\xff\xff")
+    with pytest.raises(HTTPException):
+        _peek_validate(str(p), ".csv")
+
+
+def test_valid_parquet(tmp_path):
+    p = tmp_path / "data.parquet"
+    table = pa.table({"a": [1, 2]})
+    pq.write_table(table, p)
+    _peek_validate(str(p), ".parquet")
+
+
+def test_invalid_parquet(tmp_path):
+    p = tmp_path / "bad.parquet"
+    p.write_text("not parquet")
+    with pytest.raises(HTTPException):
+        _peek_validate(str(p), ".parquet")
+
+
+def test_unsupported(tmp_path):
+    p = tmp_path / "foo.txt"
+    p.write_text("data")
+    with pytest.raises(HTTPException):
+        _peek_validate(str(p), ".txt")


### PR DESCRIPTION
## Summary
- log producer connection events using logging module
- remove temporary file on validation failure
- rename DQL topics to DLQ
- add ruff lint configuration and validation unit tests
- document linting and testing in README

## Testing
- `ruff check batch tests`
- `python -m pytest -q` *(fails: No module named pytest)*