### PR TITLE
Implement CLI formatting and timings

### DIFF
--- a/batch/api.py
+++ b/batch/api.py
@@ -130,6 +130,7 @@ async def create_job(model_id: str, file: UploadFile = File(...)):
         "model_id": model_id,
         "state": "PENDING",
         "totals": {"rows": 0, "ok": 0, "errors": 0},
+        "timings": {"waiting_ms": 0, "processing_ms": 0},
     }
     return {"job_id": job_id}
 

--- a/batch/cli.py
+++ b/batch/cli.py
@@ -1,4 +1,6 @@
 import os
+from typing import List, Dict, Any
+
 import typer
 import requests
 
@@ -9,6 +11,53 @@ model_app = typer.Typer(name="model")
 job_app = typer.Typer(name="job")
 app.add_typer(model_app)
 app.add_typer(job_app)
+
+
+def _ms_to_time(ms: int) -> str:
+    """Convert milliseconds to MM:SS string."""
+    seconds = int(ms // 1000)
+    return f"{seconds // 60:02d}:{seconds % 60:02d}"
+
+
+def _progress_bar(ok: int, total: int, state: str, width: int = 17) -> str:
+    if total <= 0:
+        bar = "-" * width
+    else:
+        filled = int((ok / total) * width)
+        remainder = width - filled
+        if state in {"FAILED", "CANCELLED"}:
+            bar = "#" * filled + "X" * remainder
+        else:
+            bar = "#" * filled + "-" * remainder
+    return f"[{bar}]"
+
+
+def _format_jobs(jobs: List[Dict[str, Any]]) -> str:
+    header = (
+        "JOB      MODEL       STATE           TOTAL   OK      ERRORS  PROGRESS      WAITING  PROCESSSING"
+    )
+    lines = [header]
+    for job in jobs:
+        total = job.get("totals", {}).get("rows", 0)
+        ok = job.get("totals", {}).get("ok", 0)
+        errors = job.get("totals", {}).get("errors", 0)
+        waiting = job.get("timings", {}).get("waiting_ms", 0)
+        processing = job.get("timings", {}).get("processing_ms", 0)
+
+        bar = _progress_bar(ok, total, job.get("state", ""))
+        percent = int((ok / total) * 100) if total else 0
+
+        model = job.get("model_id", "")
+        if len(model) > 10:
+            model = model[:8] + ".."
+
+        line = (
+            f"{job.get('id', ''):<8} {model:<11} {job.get('state', ''):<15}"
+            f" {total:>7,} {ok:>7,} {errors:>7,} {bar} {percent:>3}%   "
+            f"{_ms_to_time(waiting):>5}        {_ms_to_time(processing):>5}"
+        )
+        lines.append(line)
+    return "\n".join(lines)
 
 
 @model_app.command("list")
@@ -48,7 +97,7 @@ def model_delete(model_id: str):
 @job_app.command("list")
 def job_list():
     r = requests.get(f"{API_URL}/jobs")
-    typer.echo(r.json())
+    typer.echo(_format_jobs(r.json()))
 
 
 @job_app.command("create")
@@ -56,19 +105,28 @@ def job_create(model_id: str, data_file: str):
     with open(data_file, "rb") as f:
         files = {"file": (os.path.basename(data_file), f)}
         r = requests.post(f"{API_URL}/jobs", params={"model_id": model_id}, files=files)
-    typer.echo(r.json())
+    if r.status_code == 202:
+        typer.echo(f"job {r.json().get('job_id')} created.")
+    else:
+        typer.echo(r.text)
 
 
 @job_app.command("status")
 def job_status(job_id: str):
     r = requests.get(f"{API_URL}/jobs/{job_id}")
-    typer.echo(r.json())
+    if r.status_code == 200:
+        typer.echo(_format_jobs([r.json()]))
+    else:
+        typer.echo(r.text)
 
 
 @job_app.command("cancel")
 def job_cancel(job_id: str):
     r = requests.delete(f"{API_URL}/jobs/{job_id}")
-    typer.echo(r.json())
+    if r.status_code == 202:
+        typer.echo(f"job {job_id} cancelled")
+    else:
+        typer.echo(r.text)
 
 
 @job_app.command("rejected")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,24 @@
+import re
+from batch import cli
+
+
+def test_progress_bar_complete():
+    bar = cli._progress_bar(100, 100, "SUCCESS")
+    assert bar == "[#################]"
+
+
+def test_format_jobs():
+    job = {
+        "id": "a1b2c3d4",
+        "model_id": "fraud_detector",
+        "state": "SUCCESS",
+        "totals": {"rows": 1000, "ok": 1000, "errors": 0},
+        "timings": {"waiting_ms": 1000, "processing_ms": 2000},
+    }
+    out = cli._format_jobs([job])
+    # should contain progress bar and percent
+    assert "[#################]" in out
+    assert re.search(r"100%", out)
+    # waiting/processing should show 00:01 and 00:02
+    assert "00:01" in out
+    assert "00:02" in out


### PR DESCRIPTION
## Summary
- implement CLI helper functions for progress and timing
- show formatted tables for jobs in CLI
- store job timing fields in API data
- test CLI formatting helpers

## Testing
- `ruff check batch tests`
- `pytest -q` *(fails: command not found)*