### PR TITLE
Remove unnecessary BATCH_API_URL from worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,5 +22,4 @@ services:
     depends_on:
       - redpanda
     environment:
-      - BATCH_API_URL=http://api:8000
       - KAFKA_BOOTSTRAP=redpanda:9092


### PR DESCRIPTION
## Summary
- drop `BATCH_API_URL` from worker service in `docker-compose.yml`

## Testing
- `ruff check .`
- `pytest -q` *(fails: command not found)*