### PR TITLE
Connect worker to ClickHouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ docker-compose up --build
 ```
 
 The API will be available at `http://localhost:8000` and Redpanda at `localhost:9092`.
+ClickHouse (latest image) will be available at `http://localhost:8123`.
 Use the CLI via `python -m batch.cli`.
 Set `BATCH_API_URL` and `KAFKA_BOOTSTRAP` if running the services elsewhere:
 

--- a/batch/clickhouse.py
+++ b/batch/clickhouse.py
@@ -1,0 +1,35 @@
+import os
+from typing import Dict, Any, Iterable
+
+import clickhouse_connect
+
+CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
+CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 8123))
+
+_client = None
+
+def get_client():
+    global _client
+    if _client is None:
+        _client = clickhouse_connect.get_client(host=CLICKHOUSE_HOST, port=CLICKHOUSE_PORT)
+    return _client
+
+
+def ensure_table(model_id: str, columns: Dict[str, str]) -> None:
+    """Create per-model table if it does not already exist."""
+    cols = ", ".join(f"{name} {dtype}" for name, dtype in columns.items())
+    ddl = (
+        f"CREATE TABLE IF NOT EXISTS data_{model_id} ({cols}) "
+        "ENGINE = MergeTree ORDER BY (event_id)"
+    )
+    client = get_client()
+    client.command(ddl)
+
+
+def insert_rows(model_id: str, rows: Iterable[Dict[str, Any]]) -> None:
+    rows_list = list(rows)
+    if not rows_list:
+        return
+    columns = rows_list[0].keys()
+    client = get_client()
+    client.insert(f"data_{model_id}", rows_list, column_names=list(columns))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,15 @@ services:
     command: ["redpanda", "start", "--smp", "1", "--reserve-memory", "0M", "--overprovisioned"]
     ports:
       - "9092:9092"
+  clickhouse:
+    image: clickhouse/clickhouse-server:latest
+    ports:
+      - "8123:8123"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8123/ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
   api:
     build: .
     volumes:
@@ -21,5 +30,7 @@ services:
     command: python -m batch.worker
     depends_on:
       - redpanda
+      - clickhouse
     environment:
       - KAFKA_BOOTSTRAP=redpanda:9092
+      - CLICKHOUSE_HOST=clickhouse

--- a/docsite/clickhouse.md
+++ b/docsite/clickhouse.md
@@ -2,6 +2,9 @@
 
 Validated rows are stored in ClickHouse for analytical queries.
 
+The provided `docker-compose.yml` includes a `clickhouse` service using the latest image.
+When the stack is started locally, the database is reachable at `http://localhost:8123`.
+
 ```sql
 -- Example per-model table
 CREATE TABLE data_<model_id> (

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ aiokafka
 typer
 requests
 pyarrow
+clickhouse-connect


### PR DESCRIPTION
## Summary
- highlight that we run the latest ClickHouse image
- tweak docs for ClickHouse availability
- point ClickHouse service at the `latest` tag

## Testing
- `ruff check batch tests`
- `pytest` *(fails: command not found)*