### PR TITLE
Enhance robustness

### DIFF
--- a/batch/worker.py
+++ b/batch/worker.py
@@ -15,27 +15,33 @@ def _parse_rows(data: bytes) -> List[Dict[str, str]]:
     """Return a list of rows parsed from CSV or Parquet bytes."""
     try:
         table = pq.read_table(io.BytesIO(data))
-        return [
-            {k: str(v) for k, v in row.items()}
-            for row in table.to_pylist()
-        ]
+        return [{k: str(v) for k, v in row.items()} for row in table.to_pylist()]
     except Exception:
         text = data.decode("utf-8")
         reader = csv.DictReader(io.StringIO(text))
         return [dict(row) for row in reader]
 
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 KAFKA_BOOTSTRAP = os.environ.get("KAFKA_BOOTSTRAP", "redpanda:9092")
+KAFKA_MAX_RETRIES = 12
 
 
 async def _start(client):
+    attempts = 0
     while True:
         try:
             await client.start()
             break
         except Exception as exc:
+            attempts += 1
+            if attempts >= KAFKA_MAX_RETRIES:
+                logger.error(
+                    "Kafka connect failed after %s attempts: %s", attempts, exc
+                )
+                raise
             logger.warning("Kafka connect failed: %s. Retrying...", exc)
             await asyncio.sleep(5)
 
@@ -55,7 +61,9 @@ async def consume(job_id: str, model_id: str) -> None:
                 logger.info("Got message from %s offset %s", topic, msg.offset)
                 rows = _parse_rows(msg.value)
                 if rows:
-                    clickhouse.ensure_table(model_id, {c: "String" for c in rows[0].keys()})
+                    clickhouse.ensure_table(
+                        model_id, {c: "String" for c in rows[0].keys()}
+                    )
                     clickhouse.insert_rows(model_id, rows)
                     logger.info("Inserted %d rows into data_%s", len(rows), model_id)
             except Exception as exc:


### PR DESCRIPTION
## Summary
- handle empty CSVs and missing newlines in `_peek_validate`
- avoid loading large files at once in `create_job`
- clamp progress bar and percentage calculations
- limit Kafka connection retries for API and worker

## Testing
- `black batch/api.py batch/cli.py batch/worker.py`
- `pytest -q` *(fails: `pytest` not found)*