### PR TITLE
Add batch cli entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Create a simple JSON schema and save it as `model.json`:
 Register the model and note the returned `model_id`:
 
 ```bash
-python -m batch.cli model create purchases model.json
+batch model create purchases model.json
 ```
 
 ### 3. Ingest valid data
@@ -41,13 +41,13 @@ event_id,timestamp,amount
 Create a job for the file:
 
 ```bash
-python -m batch.cli job create <model_id> data.csv
+batch job create <model_id> data.csv
 ```
 
 Check progress until the job state becomes `SUCCESS`:
 
 ```bash
-python -m batch.cli job status <job_id>
+batch job status <job_id>
 ```
 
 Query ClickHouse to view the inserted rows:
@@ -61,13 +61,13 @@ curl "http://localhost:8123/?query=SELECT%20*%20FROM%20data_<model_id>"
 Upload a CSV containing invalid rows, e.g. `bad.csv` with missing or malformed values:
 
 ```bash
-python -m batch.cli job create <model_id> bad.csv
+batch job create <model_id> bad.csv
 ```
 
 When the job state is `PARTIAL_SUCCESS` or `FAILED`, inspect the problems:
 
 ```bash
-python -m batch.cli job rejected <job_id>
+batch job rejected <job_id>
 ```
 
 Rejected rows are also stored in ClickHouse and can be queried directly:
@@ -78,7 +78,7 @@ curl "http://localhost:8123/?query=SELECT%20*%20FROM%20rejected_rows%20WHERE%20j
 
 ## Local Development
 
-Use the CLI via `python -m batch.cli`. Set `BATCH_API_URL` and `KAFKA_BOOTSTRAP` if running the services elsewhere:
+Use the CLI via `batch`. Set `BATCH_API_URL` and `KAFKA_BOOTSTRAP` if running the services elsewhere:
 
 ```bash
 export BATCH_API_URL=http://localhost:8000

--- a/batch/__main__.py
+++ b/batch/__main__.py
@@ -1,0 +1,4 @@
+from .cli import app
+
+if __name__ == "__main__":
+    app()

--- a/docsite/cli.md
+++ b/docsite/cli.md
@@ -1,6 +1,6 @@
 # Command-Line Interface (CLI)
 
-A rich CLI is provided for interacting with the batch ingestion service. Run commands via `batch.cli <command>` or `./batchcli <command>` if the project has been built locally.
+A rich CLI is provided for interacting with the batch ingestion service. Run commands via `batch <command>` or `./batch <command>` if the project has been built locally.
 
 Ensure the API URL is set if the server is not running at the default `http://localhost:8000`:
 
@@ -14,35 +14,35 @@ export BATCH_API_URL=http://localhost:8000
 Lists available models.
 
 ```bash
-./batchcli model list
+./batch model list
 ```
 
 ### `model describe <model_id>`
 Shows details for a specific model.
 
 ```bash
-./batchcli model describe <model_id>
+./batch model describe <model_id>
 ```
 
 ### `model create <model_name> <path/to/schema.json>`
 Creates a new model from a name and a JSON schema file.
 
 ```bash
-./batchcli model create my_new_model ./schemas/new_model_schema.json
+./batch model create my_new_model ./schemas/new_model_schema.json
 ```
 
 ### `model update <model_id> <path/to/schema.json>`
 Updates the schema for an existing model.
 
 ```bash
-./batchcli model update <model_id> ./schemas/updated_schema.json
+./batch model update <model_id> ./schemas/updated_schema.json
 ```
 
 ### `model delete <model_id>`
 Deletes a model.
 
 ```bash
-./batchcli model delete <model_id>
+./batch model delete <model_id>
 ```
 
 ## Job Commands
@@ -51,7 +51,7 @@ Deletes a model.
 Lists existing jobs with their status.
 
 ```bash
-./batchcli job list
+./batch job list
 ```
 
 Sample output:
@@ -76,7 +76,7 @@ a9b0c1d2 Market Pr.. SUCCESS           3,200   3,200       0 [#################]
 Creates a new job for the given model and data file.
 
 ```bash
-./batchcli job create model_123 data.csv
+./batch job create model_123 data.csv
 ```
 
 Sample output:
@@ -89,7 +89,7 @@ job a5b6c7d8 created.
 Shows the status of a specific job.
 
 ```bash
-./batchcli job status a6b7c8d9
+./batch job status a6b7c8d9
 ```
 
 Sample output:
@@ -106,7 +106,7 @@ a5b6c7d8 model_123.. PENDING             100       0       0 [-----------------]
 Cancels a job.
 
 ```bash
-./batchcli job cancel a5b6c7d8
+./batch job cancel a5b6c7d8
 ```
 
 Sample output:
@@ -119,7 +119,7 @@ job a5b6c7d8 cancelled
 Displays rows that were rejected during processing for a specific job.
 
 ```bash
-./batchcli job rejected a5b6c7d8
+./batch job rejected a5b6c7d8
 ```
 
 Sample output:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,13 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "batch-on-kafka"
+version = "0.1.0"
+
+[project.scripts]
+batch = "batch.cli:app"
+
 [tool.ruff]
 line-length = 100
-


### PR DESCRIPTION
## Summary
- add `__main__.py` so running `batch` module executes the CLI
- expose `batch` entrypoint via `pyproject.toml`
- update README and docs to use the new `batch` command

## Testing
- `ruff check batch tests`
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'typer')*