### PR TITLE
Stabilize batch pipeline and add CLI end-to-end tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.venv
+__pycache__

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ abcd1234 purchases   SUCCESS               2       2       0 [#################]
 Query ClickHouse to view the inserted rows:
 
 ```bash
-curl "http://localhost:8123/?query=SELECT%20*%20FROM%20data_<model_id>"
+curl "http://localhost:8123/?user=default&password=batchlocal&query=SELECT%20*%20FROM%20data_<model_id>"
 ```
 
 Sample output:
@@ -128,7 +128,7 @@ ROW,EVENT_ID,COLUMN,TYPE,ERROR,OBSERVED,MESSAGE
 Rejected rows are also stored in ClickHouse and can be queried directly:
 
 ```bash
-curl "http://localhost:8123/?query=SELECT%20*%20FROM%20rejected_rows%20WHERE%20job_id='<job_id>'"
+curl "http://localhost:8123/?user=default&password=batchlocal&query=SELECT%20*%20FROM%20rejected_rows%20WHERE%20job_id='<job_id>'"
 ```
 
 Sample output:
@@ -146,6 +146,7 @@ export BATCH_API_URL=http://localhost:8000
 export KAFKA_BOOTSTRAP=localhost:9092
 export CLICKHOUSE_HOST=localhost
 export CLICKHOUSE_PORT=8123
+export CLICKHOUSE_PASSWORD=batchlocal
 ```
 
 Start the services locally without Docker using:
@@ -157,14 +158,17 @@ python -m batch.worker          # background worker
 
 ### Linting and Tests
 
-Install development dependencies and run the linter and test suite:
+Install development dependencies and run the linter and test suite. Unit tests
+run with the default command. Live end-to-end CLI coverage is available through
+the same suite when `BATCH_E2E=1` is set and the local stack is running.
 
 ```bash
 pip install ruff
 ruff batch tests
 python -m unittest discover -s tests
+
+docker-compose up --build -d
+BATCH_E2E=1 python -m unittest discover -s tests
 ```
 
 See [docsite](./docsite) for detailed API and schema information.
-
-

--- a/batch/api.py
+++ b/batch/api.py
@@ -1,14 +1,18 @@
-from fastapi import FastAPI, UploadFile, File, HTTPException, status, Request
-from fastapi.responses import JSONResponse, StreamingResponse
-from uuid import uuid4
-import os
-import csv
 import asyncio
+import base64
+import csv
+import io
+import json
 import logging
-from typing import Dict, Any, Optional
+import os
+import time
+from typing import Any, Dict, Optional
+from uuid import uuid4
 
 import pyarrow.parquet as pq
 from aiokafka import AIOKafkaProducer
+from fastapi import FastAPI, File, HTTPException, Response, UploadFile, status
+from fastapi.responses import StreamingResponse
 
 app = FastAPI()
 
@@ -17,18 +21,47 @@ JOBS: Dict[str, Dict[str, Any]] = {}
 MAX_FILE_SIZE = 1 * 1024 * 1024 * 1024  # 1GB
 KAFKA_BOOTSTRAP = os.environ.get("KAFKA_BOOTSTRAP", "redpanda:9092")
 _producer: Optional[AIOKafkaProducer] = None
+_producer_started = False
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+def _job_topic(job_id: str) -> str:
+    return f"batch.{job_id}"
+
+
+def _encode_job_message(
+    job_id: str,
+    model_id: str,
+    schema: str,
+    filename: str,
+    contents: bytes,
+    created_at_ms: int,
+) -> bytes:
+    return json.dumps(
+        {
+            "job_id": job_id,
+            "model_id": model_id,
+            "schema": schema,
+            "filename": filename,
+            "created_at_ms": created_at_ms,
+            "payload_b64": base64.b64encode(contents).decode("ascii"),
+        }
+    ).encode("utf-8")
+
+
 async def get_producer() -> AIOKafkaProducer:
-    global _producer
+    global _producer, _producer_started
     if _producer is None:
         _producer = AIOKafkaProducer(bootstrap_servers=KAFKA_BOOTSTRAP)
+    if _producer_started:
+        return _producer
+
     while True:
         try:
             await _producer.start()
+            _producer_started = True
             logger.info("Connected to Kafka at %s", KAFKA_BOOTSTRAP)
             break
         except Exception as exc:
@@ -37,17 +70,25 @@ async def get_producer() -> AIOKafkaProducer:
     return _producer
 
 
-def _peek_validate(file_path: str, ext: str):
+@app.on_event("shutdown")
+async def shutdown_producer() -> None:
+    global _producer_started
+    if _producer is not None and _producer_started:
+        await _producer.stop()
+        _producer_started = False
+
+
+def _peek_validate(file_path: str, ext: str) -> None:
     """Peek into the file to ensure it's a valid CSV or Parquet."""
     if ext == ".csv":
         with open(file_path, "rb") as f:
             head = f.read(1024)
         try:
             text = head.decode("utf-8")
-        except UnicodeDecodeError as e:
+        except UnicodeDecodeError as exc:
             raise HTTPException(
-                status.HTTP_400_BAD_REQUEST, detail=f"Invalid CSV encoding: {e}"
-            )
+                status.HTTP_400_BAD_REQUEST, detail=f"Invalid CSV encoding: {exc}"
+            ) from exc
         lines = text.splitlines()
         if not lines:
             raise HTTPException(
@@ -55,24 +96,54 @@ def _peek_validate(file_path: str, ext: str):
             )
         try:
             csv.reader([lines[0]])
-        except Exception as e:
+        except Exception as exc:
             raise HTTPException(
-                status.HTTP_400_BAD_REQUEST, detail=f"Invalid CSV content: {e}"
-            )
-    elif ext == ".parquet":
+                status.HTTP_400_BAD_REQUEST, detail=f"Invalid CSV content: {exc}"
+            ) from exc
+        return
+
+    if ext == ".parquet":
         try:
             pq.ParquetFile(file_path)
-        except Exception as e:
+        except Exception as exc:
             raise HTTPException(
-                status.HTTP_400_BAD_REQUEST, detail=f"Invalid Parquet file: {e}"
-            )
-    else:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Unsupported file type")
+                status.HTTP_400_BAD_REQUEST, detail=f"Invalid Parquet file: {exc}"
+            ) from exc
+        return
+
+    raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Unsupported file type")
+
+
+def _rejected_rows_csv(rows: list[Dict[str, Any]]) -> str:
+    buffer = io.StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(["ROW", "EVENT_ID", "COLUMN", "TYPE", "ERROR", "OBSERVED", "MESSAGE"])
+    for row in rows:
+        writer.writerow(
+            [
+                row.get("row", ""),
+                row.get("event_id", ""),
+                row.get("column", ""),
+                row.get("type", ""),
+                row.get("error", ""),
+                row.get("observed", ""),
+                row.get("message", ""),
+            ]
+        )
+    return buffer.getvalue()
 
 
 @app.get("/models")
 def list_models():
     return list(MODELS.values())
+
+
+@app.get("/models/{model_id}")
+def get_model(model_id: str):
+    model = MODELS.get(model_id)
+    if not model:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Model not found")
+    return model
 
 
 @app.post("/models", status_code=status.HTTP_201_CREATED)
@@ -94,12 +165,13 @@ def update_model(model_id: str, model: Dict[str, Any]):
 def delete_model(model_id: str):
     if MODELS.pop(model_id, None) is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Model not found")
-    return JSONResponse(status_code=status.HTTP_204_NO_CONTENT)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @app.post("/jobs", status_code=status.HTTP_202_ACCEPTED)
 async def create_job(model_id: str, file: UploadFile = File(...)):
-    if model_id not in MODELS:
+    model = MODELS.get(model_id)
+    if model is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Model not found")
 
     ext = os.path.splitext(file.filename)[1].lower()
@@ -125,31 +197,49 @@ async def create_job(model_id: str, file: UploadFile = File(...)):
                 )
             f.write(chunk)
 
-    with open(tmp_path, "rb") as f:
-        contents = f.read()
-
-    job_id = uuid4().hex[:8]
-    topic = f"/batch/{job_id}"
     try:
         _peek_validate(tmp_path, ext)
+        with open(tmp_path, "rb") as f:
+            contents = f.read()
     except HTTPException:
         os.remove(tmp_path)
         raise
 
-    producer = await get_producer()
-    try:
-        await producer.send_and_wait(topic, contents)
-        logger.info("Created job %s on topic %s", job_id, topic)
-    finally:
-        os.remove(tmp_path)
-
+    job_id = uuid4().hex[:8]
+    created_at_ms = int(time.time() * 1000)
     JOBS[job_id] = {
         "id": job_id,
         "model_id": model_id,
         "state": "PENDING",
         "totals": {"rows": 0, "ok": 0, "errors": 0},
         "timings": {"waiting_ms": 0, "processing_ms": 0},
+        "rejected_rows": [],
+        "created_at_ms": created_at_ms,
     }
+
+    producer = await get_producer()
+    try:
+        await producer.send_and_wait(
+            _job_topic(job_id),
+            _encode_job_message(
+                job_id=job_id,
+                model_id=model_id,
+                schema=model["schema"],
+                filename=file.filename,
+                contents=contents,
+                created_at_ms=created_at_ms,
+            ),
+        )
+        logger.info("Created job %s on topic %s", job_id, _job_topic(job_id))
+    except Exception as exc:
+        JOBS.pop(job_id, None)
+        logger.exception("Failed to enqueue job %s", job_id)
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE, detail="Unable to enqueue job"
+        ) from exc
+    finally:
+        os.remove(tmp_path)
+
     return {"job_id": job_id}
 
 
@@ -163,6 +253,28 @@ def job_status(job_id: str):
     job = JOBS.get(job_id)
     if not job:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Job not found")
+    return job
+
+
+@app.put("/internal/jobs/{job_id}")
+def update_job(job_id: str, update: Dict[str, Any]):
+    job = JOBS.get(job_id)
+    if not job:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Job not found")
+
+    if job.get("state") == "CANCELLED":
+        return job
+
+    if "state" in update:
+        job["state"] = update["state"]
+    if "totals" in update:
+        job["totals"] = update["totals"]
+    if "timings" in update:
+        job["timings"] = update["timings"]
+    if "rejected_rows" in update:
+        job["rejected_rows"] = update["rejected_rows"]
+    if "detail" in update:
+        job["detail"] = update["detail"]
     return job
 
 
@@ -181,9 +293,7 @@ def rejected_rows(job_id: str):
     if not job:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Job not found")
 
-    async def iterator():
-        yield "ROW,EVENT_ID,COLUMN,TYPE,ERROR,OBSERVED,MESSAGE\n"
-
-    return StreamingResponse(iterator(), media_type="text/csv")
-
-
+    return StreamingResponse(
+        iter([_rejected_rows_csv(job.get("rejected_rows", []))]),
+        media_type="text/csv",
+    )

--- a/batch/clickhouse.py
+++ b/batch/clickhouse.py
@@ -5,22 +5,38 @@ import clickhouse_connect
 
 CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
 CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 8123))
+CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
+CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD", "")
 
 _client = None
+
 
 def get_client():
     global _client
     if _client is None:
-        _client = clickhouse_connect.get_client(host=CLICKHOUSE_HOST, port=CLICKHOUSE_PORT)
+        kwargs = {
+            "host": CLICKHOUSE_HOST,
+            "port": CLICKHOUSE_PORT,
+            "username": CLICKHOUSE_USER,
+        }
+        if CLICKHOUSE_PASSWORD:
+            kwargs["password"] = CLICKHOUSE_PASSWORD
+        _client = clickhouse_connect.get_client(**kwargs)
     return _client
 
 
 def ensure_table(model_id: str, columns: Dict[str, str]) -> None:
     """Create per-model table if it does not already exist."""
+    if not columns:
+        return
     cols = ", ".join(f"{name} {dtype}" for name, dtype in columns.items())
+    if "event_id" in columns:
+        order_by = "event_id"
+    else:
+        order_by = next(iter(columns))
     ddl = (
         f"CREATE TABLE IF NOT EXISTS data_{model_id} ({cols}) "
-        "ENGINE = MergeTree ORDER BY (event_id)"
+        f"ENGINE = MergeTree ORDER BY ({order_by})"
     )
     client = get_client()
     client.command(ddl)
@@ -30,6 +46,48 @@ def insert_rows(model_id: str, rows: Iterable[Dict[str, Any]]) -> None:
     rows_list = list(rows)
     if not rows_list:
         return
-    columns = rows_list[0].keys()
+    columns = list(rows_list[0].keys())
+    values = [[row[column] for column in columns] for row in rows_list]
     client = get_client()
-    client.insert(f"data_{model_id}", rows_list, column_names=list(columns))
+    client.insert(f"data_{model_id}", values, column_names=columns)
+
+
+def ensure_rejected_table() -> None:
+    ddl = """
+        CREATE TABLE IF NOT EXISTS rejected_rows (
+            job_id String,
+            row UInt32,
+            event_id String,
+            column String,
+            type String,
+            error String,
+            observed String,
+            message String,
+            ts DateTime DEFAULT now()
+        ) ENGINE = MergeTree
+        ORDER BY (job_id, row)
+    """
+    client = get_client()
+    client.command(ddl)
+
+
+def insert_rejected_rows(job_id: str, rows: Iterable[Dict[str, Any]]) -> None:
+    payload = [
+        {
+            "job_id": job_id,
+            "row": int(row["row"]),
+            "event_id": row.get("event_id", ""),
+            "column": row.get("column", ""),
+            "type": row.get("type", ""),
+            "error": row.get("error", ""),
+            "observed": row.get("observed", ""),
+            "message": row.get("message", ""),
+        }
+        for row in rows
+    ]
+    if not payload:
+        return
+    columns = ["job_id", "row", "event_id", "column", "type", "error", "observed", "message"]
+    values = [[row[column] for column in columns] for row in payload]
+    client = get_client()
+    client.insert("rejected_rows", values, column_names=columns)

--- a/batch/worker.py
+++ b/batch/worker.py
@@ -1,34 +1,200 @@
 import asyncio
+import base64
 import csv
 import io
+import json
 import logging
 import os
-from typing import List, Dict
+import time
+from typing import Any, Dict, List, Tuple
 
 import pyarrow.parquet as pq
+import requests
 from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
 
 from . import clickhouse
-
-
-def _parse_rows(data: bytes) -> List[Dict[str, str]]:
-    """Return a list of rows parsed from CSV or Parquet bytes."""
-    try:
-        table = pq.read_table(io.BytesIO(data))
-        return [{k: str(v) for k, v in row.items()} for row in table.to_pylist()]
-    except Exception:
-        text = data.decode("utf-8")
-        reader = csv.DictReader(io.StringIO(text))
-        return [dict(row) for row in reader]
-
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 KAFKA_BOOTSTRAP = os.environ.get("KAFKA_BOOTSTRAP", "redpanda:9092")
+API_URL = os.environ.get("BATCH_API_URL", "http://api:8000")
+CANCELLATION_GRACE_MS = int(os.environ.get("BATCH_CANCELLATION_GRACE_MS", "500"))
 
 
-async def _start(client):
+def _parse_rows(data: bytes, filename: str) -> List[Dict[str, Any]]:
+    """Return a list of rows parsed from CSV or Parquet bytes."""
+    ext = os.path.splitext(filename)[1].lower()
+    if ext == ".parquet":
+        table = pq.read_table(io.BytesIO(data))
+        return [dict(row) for row in table.to_pylist()]
+
+    if ext == ".csv":
+        text = data.decode("utf-8")
+        reader = csv.DictReader(io.StringIO(text))
+        return [dict(row) for row in reader]
+
+    raise ValueError(f"Unsupported file type: {ext}")
+
+
+def _decode_job_message(data: bytes) -> Dict[str, Any]:
+    payload = json.loads(data.decode("utf-8"))
+    payload["file_bytes"] = base64.b64decode(payload["payload_b64"])
+    return payload
+
+
+def _load_schema(schema_text: str) -> Dict[str, str]:
+    schema = json.loads(schema_text)
+    if not isinstance(schema, dict) or not schema:
+        raise ValueError("Schema must be a non-empty JSON object")
+    return {str(key): str(value) for key, value in schema.items()}
+
+
+def _invalid_value(column: str, dtype: str, value: Any, error: str, message: str) -> Dict[str, str]:
+    observed = "" if value is None else str(value)
+    return {
+        "column": column,
+        "type": dtype,
+        "error": error,
+        "observed": observed,
+        "message": message,
+    }
+
+
+def _coerce_row_value(column: str, dtype: str, value: Any) -> Tuple[Any, Dict[str, str] | None]:
+    if value in (None, ""):
+        return None, _invalid_value(
+            column,
+            dtype,
+            value,
+            "MISSING_COLUMN",
+            f"The required column '{column}' is missing",
+        )
+
+    if dtype == "String":
+        return str(value), None
+
+    if dtype == "UInt32":
+        try:
+            if isinstance(value, float) and not value.is_integer():
+                raise ValueError("non-integer float")
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return None, _invalid_value(
+                column,
+                dtype,
+                value,
+                "INVALID_UINT32",
+                f"The value for '{column}' must be an unsigned 32-bit integer",
+            )
+        if parsed < 0 or parsed > 4294967295:
+            return None, _invalid_value(
+                column,
+                dtype,
+                value,
+                "INVALID_UINT32",
+                f"The value for '{column}' must be an unsigned 32-bit integer",
+            )
+        return parsed, None
+
+    if dtype == "Float64":
+        try:
+            return float(value), None
+        except (TypeError, ValueError):
+            return None, _invalid_value(
+                column,
+                dtype,
+                value,
+                "INVALID_FLOAT64",
+                f"The value for '{column}' must be a float",
+            )
+
+    return None, _invalid_value(
+        column,
+        dtype,
+        value,
+        "UNSUPPORTED_TYPE",
+        f"Unsupported schema type '{dtype}'",
+    )
+
+
+def _validate_rows(
+    rows: List[Dict[str, Any]], schema: Dict[str, str]
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], int]:
+    valid_rows: List[Dict[str, Any]] = []
+    rejected_rows: List[Dict[str, Any]] = []
+    invalid_row_count = 0
+
+    for row_number, row in enumerate(rows, start=1):
+        typed_row: Dict[str, Any] = {}
+        row_errors: List[Dict[str, str]] = []
+        event_id = "" if row.get("event_id") in (None, "") else str(row.get("event_id"))
+
+        for column, dtype in schema.items():
+            coerced_value, error = _coerce_row_value(column, dtype, row.get(column))
+            if error is not None:
+                row_errors.append(
+                    {
+                        "row": row_number,
+                        "event_id": event_id,
+                        **error,
+                    }
+                )
+                continue
+            typed_row[column] = coerced_value
+
+        if row_errors:
+            invalid_row_count += 1
+            rejected_rows.extend(row_errors)
+            continue
+
+        valid_rows.append(typed_row)
+
+    return valid_rows, rejected_rows, invalid_row_count
+
+
+def _job_update(
+    state: str,
+    total_rows: int,
+    ok_rows: int,
+    error_rows: int,
+    waiting_ms: int,
+    processing_ms: int,
+    rejected_rows: List[Dict[str, Any]],
+    detail: str | None = None,
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "state": state,
+        "totals": {"rows": total_rows, "ok": ok_rows, "errors": error_rows},
+        "timings": {"waiting_ms": waiting_ms, "processing_ms": processing_ms},
+        "rejected_rows": rejected_rows,
+    }
+    if detail:
+        payload["detail"] = detail
+    return payload
+
+
+def _update_job(job_id: str, payload: Dict[str, Any]) -> None:
+    response = requests.put(f"{API_URL}/internal/jobs/{job_id}", json=payload, timeout=10)
+    response.raise_for_status()
+
+
+def _get_job_state(job_id: str) -> str:
+    response = requests.get(f"{API_URL}/jobs/{job_id}", timeout=10)
+    response.raise_for_status()
+    return str(response.json().get("state", ""))
+
+
+def _job_is_cancelled(job_id: str) -> bool:
+    return _get_job_state(job_id) == "CANCELLED"
+
+
+def _processing_delay_ms(created_at_ms: int, now_ms: int) -> int:
+    ready_at_ms = created_at_ms + CANCELLATION_GRACE_MS
+    return max(0, ready_at_ms - now_ms)
+
+
+async def _start(client) -> None:
     while True:
         try:
             await client.start()
@@ -38,44 +204,109 @@ async def _start(client):
             await asyncio.sleep(5)
 
 
-async def consume(job_id: str, model_id: str) -> None:
-    """Consume the job topic and insert rows into ClickHouse."""
-    topic = f"/batch/{job_id}"
-    dlq_topic = f"/batch/{job_id}/dlq"
-    consumer = AIOKafkaConsumer(topic, bootstrap_servers=KAFKA_BOOTSTRAP)
+async def consume() -> None:
+    """Consume all job topics and insert rows into ClickHouse."""
+    consumer = AIOKafkaConsumer(
+        bootstrap_servers=KAFKA_BOOTSTRAP,
+        group_id="batch-worker",
+        auto_offset_reset="earliest",
+        metadata_max_age_ms=1000,
+    )
+    consumer.subscribe(pattern=r"^batch\.[^.]+$")
     producer = AIOKafkaProducer(bootstrap_servers=KAFKA_BOOTSTRAP)
     await _start(consumer)
     await _start(producer)
 
     try:
         async for msg in consumer:
+            job_id = ""
+            started_at_ms = int(time.time() * 1000)
             try:
-                logger.info("Got message from %s offset %s", topic, msg.offset)
-                start = asyncio.get_event_loop().time()
-                rows = _parse_rows(msg.value)
-                if rows:
-                    clickhouse.ensure_table(
-                        model_id, {c: "String" for c in rows[0].keys()}
-                    )
-                    clickhouse.insert_rows(model_id, rows)
-                    logger.info(
-                        "Inserted %d rows into data_%s", len(rows), model_id
-                    )
-                
+                payload = _decode_job_message(msg.value)
+                job_id = payload["job_id"]
+                created_at_ms = int(payload.get("created_at_ms", started_at_ms))
+                delay_ms = _processing_delay_ms(created_at_ms, started_at_ms)
+                if delay_ms:
+                    await asyncio.sleep(delay_ms / 1000)
+                if await asyncio.to_thread(_job_is_cancelled, job_id):
+                    logger.info("Skipping cancelled job %s before processing", job_id)
+                    continue
+                model_id = payload["model_id"]
+                schema = _load_schema(payload["schema"])
+                rows = _parse_rows(payload["file_bytes"], payload["filename"])
+                processing_started_at_ms = int(time.time() * 1000)
+                waiting_ms = max(
+                    0, processing_started_at_ms - created_at_ms
+                )
+                valid_rows, rejected_rows, invalid_row_count = _validate_rows(rows, schema)
+
+                if await asyncio.to_thread(_job_is_cancelled, job_id):
+                    logger.info("Skipping cancelled job %s before persistence", job_id)
+                    continue
+
+                if valid_rows:
+                    clickhouse.ensure_table(model_id, schema)
+                    clickhouse.insert_rows(model_id, valid_rows)
+                if rejected_rows:
+                    clickhouse.ensure_rejected_table()
+                    clickhouse.insert_rejected_rows(job_id, rejected_rows)
+
+                processing_ms = max(0, int(time.time() * 1000) - started_at_ms)
+                if invalid_row_count == 0:
+                    state = "SUCCESS"
+                elif valid_rows:
+                    state = "PARTIAL_SUCCESS"
+                else:
+                    state = "FAILED"
+
+                await asyncio.to_thread(
+                    _update_job,
+                    job_id,
+                    _job_update(
+                        state=state,
+                        total_rows=len(rows),
+                        ok_rows=len(valid_rows),
+                        error_rows=invalid_row_count,
+                        waiting_ms=waiting_ms,
+                        processing_ms=processing_ms,
+                        rejected_rows=rejected_rows,
+                    ),
+                )
+                logger.info("Processed job %s with state %s", job_id, state)
             except Exception as exc:
-                logger.error("Processing failed: %s", exc)
-                await producer.send_and_wait(dlq_topic, msg.value)
+                logger.exception("Processing failed: %s", exc)
+                if job_id:
+                    if await asyncio.to_thread(_job_is_cancelled, job_id):
+                        logger.info("Skipping failure handling for cancelled job %s", job_id)
+                        continue
+                    processing_ms = max(0, int(time.time() * 1000) - started_at_ms)
+                    await producer.send_and_wait(f"batch.{job_id}.dlq", msg.value)
+                    try:
+                        await asyncio.to_thread(
+                            _update_job,
+                            job_id,
+                            _job_update(
+                                state="FAILED",
+                                total_rows=0,
+                                ok_rows=0,
+                                error_rows=0,
+                                waiting_ms=0,
+                                processing_ms=processing_ms,
+                                rejected_rows=[],
+                                detail=str(exc),
+                            ),
+                        )
+                    except Exception:
+                        logger.exception("Failed to update job %s in API", job_id)
     finally:
         await consumer.stop()
         await producer.stop()
 
 
-def main(job_id: str = "testjob", model_id: str = "model") -> None:
+def main() -> None:
     """Entry point for the worker."""
-    asyncio.run(consume(job_id, model_id))
+    asyncio.run(consume())
 
 
 if __name__ == "__main__":
-    env_job = os.environ.get("JOB_ID", "testjob")
-    env_model = os.environ.get("MODEL_ID", "model")
-    main(env_job, env_model)
+    main()

--- a/clickhouse/default-user.xml
+++ b/clickhouse/default-user.xml
@@ -1,0 +1,13 @@
+<clickhouse>
+  <users>
+    <default>
+      <password>batchlocal</password>
+      <networks>
+        <ip>::/0</ip>
+      </networks>
+      <profile>default</profile>
+      <quota>default</quota>
+      <access_management>1</access_management>
+    </default>
+  </users>
+</clickhouse>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,35 @@
 services:
 
   redpanda:
-    image: docker.redpanda.com/redpanda/redpanda:latest
-    command: ["redpanda", "start", "--smp", "1", "--reserve-memory", "0M", "--overprovisioned"]
+    image: docker.redpanda.com/redpandadata/redpanda:latest
+    command:
+      [
+        "redpanda",
+        "start",
+        "--smp",
+        "1",
+        "--reserve-memory",
+        "0M",
+        "--overprovisioned",
+        "--check=false",
+        "--node-id",
+        "0",
+        "--kafka-addr",
+        "PLAINTEXT://0.0.0.0:9092",
+        "--advertise-kafka-addr",
+        "PLAINTEXT://redpanda:9092"
+      ]
     ports:
       - "9092:9092"
       
   clickhouse:
     image: clickhouse/clickhouse-server:latest
+    volumes:
+      - ./clickhouse/default-user.xml:/etc/clickhouse-server/users.d/default-user.xml:ro
     ports:
       - "8123:8123"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8123/ping"]
+      test: ["CMD", "clickhouse-client", "--user", "default", "--password", "batchlocal", "--query", "SELECT 1"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -30,7 +48,8 @@ services:
     build: .
     command: python -m batch.worker
     environment:
+      - BATCH_API_URL=http://api:8000
       - KAFKA_BOOTSTRAP=redpanda:9092
       - CLICKHOUSE_HOST=clickhouse
-
-
+      - CLICKHOUSE_USER=default
+      - CLICKHOUSE_PASSWORD=batchlocal

--- a/docsite/clickhouse.md
+++ b/docsite/clickhouse.md
@@ -4,6 +4,7 @@ Validated rows are stored in ClickHouse for analytical queries.
 
 The provided `docker-compose.yml` includes a `clickhouse` service using the latest image.
 When the stack is started locally, the database is reachable at `http://localhost:8123`.
+Use `default` / `batchlocal` when querying it from the host.
 
 ```sql
 -- Example per-model table

--- a/docsite/kafka-topics.md
+++ b/docsite/kafka-topics.md
@@ -5,7 +5,7 @@ The system uses Redpanda as the Kafka broker. Topics are created dynamically per
 | Purpose | Name | Partitions | Cleanup | Retention |
 |---------|------|-----------|---------|-----------|
 | Job metadata | `batch.jobs` | 3 | compact | infinite |
-| Per-job data | `/batch/<job_id>` | 6 | delete | 1 day (configurable via `RETENTION_HOURS`) |
-| Per-job dead-letter | `/batch/<job_id>/dlq` | 6 | delete | 1 day (same as above) |
+| Per-job data | `batch.<job_id>` | 6 | delete | 1 day (configurable via `RETENTION_HOURS`) |
+| Per-job dead-letter | `batch.<job_id>.dlq` | 6 | delete | 1 day (same as above) |
 
 A compacted topic `batch.models` stores model schemas so both services can reload them on startup.

--- a/docsite/schemas.md
+++ b/docsite/schemas.md
@@ -12,12 +12,12 @@
 }
 ```
 
-## Data Row (`/batch/<job_id>`)
+## Data Row (`batch.<job_id>`)
 ```json
 {"offset": 0, "payload": "<raw-csv-or-parquet-row-as-bytes>"}
 ```
 
-## Dead-Letter Row (`/batch/<job_id>/dlq`)
+## Dead-Letter Row (`batch.<job_id>.dlq`)
 ```json
 {
   "row": 1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,5 +9,8 @@ version = "0.1.0"
 [project.scripts]
 batch = "batch.cli:app"
 
+[tool.setuptools]
+packages = ["batch"]
+
 [tool.ruff]
 line-length = 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ typer
 requests
 pyarrow
 clickhouse-connect
+python-multipart

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,36 @@
+import unittest
+
+from batch import api
+
+
+class ApiTests(unittest.TestCase):
+    def setUp(self):
+        self.models = api.MODELS.copy()
+        api.MODELS.clear()
+
+    def tearDown(self):
+        api.MODELS.clear()
+        api.MODELS.update(self.models)
+
+    def test_get_model_returns_model(self):
+        api.MODELS["abcd1234"] = {
+            "id": "abcd1234",
+            "name": "purchases",
+            "schema": "{}",
+        }
+
+        model = api.get_model("abcd1234")
+
+        self.assertEqual(model["name"], "purchases")
+
+    def test_delete_model_returns_no_content(self):
+        api.MODELS["abcd1234"] = {
+            "id": "abcd1234",
+            "name": "purchases",
+            "schema": "{}",
+        }
+
+        response = api.delete_model("abcd1234")
+
+        self.assertEqual(response.status_code, 204)
+        self.assertNotIn("abcd1234", api.MODELS)

--- a/tests/test_cli_e2e.py
+++ b/tests/test_cli_e2e.py
@@ -1,0 +1,238 @@
+import ast
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import uuid
+from pathlib import Path
+
+import requests
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+API_URL = os.environ.get("BATCH_API_URL", "http://localhost:8000")
+CLICKHOUSE_URL = os.environ.get("CLICKHOUSE_URL", "http://localhost:8123")
+CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
+CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD", "batchlocal")
+
+
+class CliE2ETests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if os.environ.get("BATCH_E2E") != "1":
+            raise unittest.SkipTest("set BATCH_E2E=1 to run live CLI end-to-end tests")
+        cls.cli = Path(sys.executable).with_name("batch")
+        cls.env = os.environ.copy()
+        cls.env["BATCH_API_URL"] = API_URL
+        cls._wait_for_stack()
+
+    @classmethod
+    def _wait_for_stack(cls) -> None:
+        deadline = time.time() + 60
+        last_error = "stack did not become ready"
+        while time.time() < deadline:
+            try:
+                api_response = requests.get(f"{API_URL}/models", timeout=2)
+                api_response.raise_for_status()
+                clickhouse_response = requests.get(
+                    CLICKHOUSE_URL,
+                    params={
+                        "user": CLICKHOUSE_USER,
+                        "password": CLICKHOUSE_PASSWORD,
+                        "query": "SELECT 1",
+                    },
+                    timeout=2,
+                )
+                clickhouse_response.raise_for_status()
+                return
+            except Exception as exc:
+                last_error = str(exc)
+                time.sleep(1)
+        raise RuntimeError(last_error)
+
+    def _run_cli(self, *args: str, timeout: int = 30) -> str:
+        proc = subprocess.run(
+            [str(self.cli), *args],
+            cwd=REPO_ROOT,
+            env=self.env,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if proc.returncode != 0:
+            raise AssertionError(
+                f"CLI command failed: {' '.join(args)}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+            )
+        return proc.stdout.strip()
+
+    def _literal_output(self, *args: str):
+        return ast.literal_eval(self._run_cli(*args))
+
+    def _write_file(self, directory: str, name: str, content: str) -> str:
+        path = Path(directory, name)
+        path.write_text(content, encoding="utf-8")
+        return str(path)
+
+    def _wait_for_job_state(self, job_id: str, expected_state: str) -> str:
+        deadline = time.time() + 60
+        last_output = ""
+        while time.time() < deadline:
+            last_output = self._run_cli("job", "status", job_id)
+            if expected_state in last_output:
+                return last_output
+            time.sleep(1)
+        raise AssertionError(
+            f"job {job_id} did not reach {expected_state}\nlast output:\n{last_output}"
+        )
+
+    def _query_clickhouse(self, query: str) -> list[str]:
+        response = requests.get(
+            CLICKHOUSE_URL,
+            params={
+                "user": CLICKHOUSE_USER,
+                "password": CLICKHOUSE_PASSWORD,
+                "query": query,
+            },
+            timeout=10,
+        )
+        response.raise_for_status()
+        return response.text.strip().splitlines() if response.text.strip() else []
+
+    def test_all_cli_commands_end_to_end(self):
+        model_name = f"e2e_{uuid.uuid4().hex[:8]}"
+        schema = {"event_id": "String", "timestamp": "UInt32", "amount": "Float64"}
+        model_id = None
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            schema_path = self._write_file(
+                tmpdir,
+                "schema.json",
+                json.dumps(schema, separators=(",", ":")),
+            )
+            updated_schema_path = self._write_file(
+                tmpdir,
+                "updated-schema.json",
+                json.dumps(schema, indent=2, sort_keys=True),
+            )
+            valid_csv_path = self._write_file(
+                tmpdir,
+                "valid.csv",
+                "event_id,timestamp,amount\n1,1716045542,12.5\n2,1716045543,8.0\n",
+            )
+            partial_csv_path = self._write_file(
+                tmpdir,
+                "partial.csv",
+                "event_id,timestamp,amount\n3,1716045544,9.1\n4,bad,\n",
+            )
+
+            try:
+                initial_models = self._literal_output("model", "list")
+                self.assertIsInstance(initial_models, list)
+
+                created_model = self._literal_output("model", "create", model_name, schema_path)
+                model_id = created_model["id"]
+                self.assertEqual(created_model["name"], model_name)
+
+                listed_models = self._literal_output("model", "list")
+                self.assertIn(model_id, {model["id"] for model in listed_models})
+
+                described_model = self._literal_output("model", "describe", model_id)
+                self.assertEqual(described_model["id"], model_id)
+                self.assertEqual(described_model["schema"], json.dumps(schema, separators=(",", ":")))
+
+                updated_model = self._literal_output("model", "update", model_id, updated_schema_path)
+                self.assertEqual(
+                    updated_model["schema"],
+                    json.dumps(schema, indent=2, sort_keys=True),
+                )
+
+                initial_job_list = self._run_cli("job", "list")
+                self.assertIn("JOB", initial_job_list)
+
+                valid_create_output = self._run_cli("job", "create", model_id, valid_csv_path)
+                valid_job_match = re.search(r"job ([0-9a-f]+) created\.", valid_create_output)
+                self.assertIsNotNone(valid_job_match)
+                valid_job_id = valid_job_match.group(1)
+
+                valid_status_output = self._wait_for_job_state(valid_job_id, "SUCCESS")
+                self.assertIn(valid_job_id, valid_status_output)
+
+                job_list_after_success = self._run_cli("job", "list")
+                self.assertIn(valid_job_id, job_list_after_success)
+                self.assertIn("SUCCESS", job_list_after_success)
+
+                inserted_rows = self._query_clickhouse(
+                    f"SELECT event_id,timestamp,amount FROM data_{model_id} ORDER BY event_id FORMAT TabSeparated"
+                )
+                self.assertEqual(
+                    inserted_rows,
+                    ["1\t1716045542\t12.5", "2\t1716045543\t8"],
+                )
+
+                partial_create_output = self._run_cli("job", "create", model_id, partial_csv_path)
+                partial_job_match = re.search(r"job ([0-9a-f]+) created\.", partial_create_output)
+                self.assertIsNotNone(partial_job_match)
+                partial_job_id = partial_job_match.group(1)
+
+                partial_status_output = self._wait_for_job_state(partial_job_id, "PARTIAL_SUCCESS")
+                self.assertIn(partial_job_id, partial_status_output)
+
+                rejected_output = self._run_cli("job", "rejected", partial_job_id)
+                self.assertIn("ROW,EVENT_ID,COLUMN,TYPE,ERROR,OBSERVED,MESSAGE", rejected_output)
+                self.assertIn("INVALID_UINT32", rejected_output)
+                self.assertIn("MISSING_COLUMN", rejected_output)
+
+                rejected_rows = self._query_clickhouse(
+                    "SELECT job_id,row,event_id,column,error "
+                    f"FROM rejected_rows WHERE job_id='{partial_job_id}' "
+                    "ORDER BY row, column FORMAT TabSeparated"
+                )
+                self.assertEqual(
+                    rejected_rows,
+                    [
+                        f"{partial_job_id}\t2\t4\tamount\tMISSING_COLUMN",
+                        f"{partial_job_id}\t2\t4\ttimestamp\tINVALID_UINT32",
+                    ],
+                )
+
+                cancel_create_output = self._run_cli("job", "create", model_id, valid_csv_path)
+                cancel_job_match = re.search(r"job ([0-9a-f]+) created\.", cancel_create_output)
+                self.assertIsNotNone(cancel_job_match)
+                cancel_job_id = cancel_job_match.group(1)
+
+                cancel_output = self._run_cli("job", "cancel", cancel_job_id)
+                self.assertEqual(cancel_output, f"job {cancel_job_id} cancelled")
+
+                cancel_status_output = self._wait_for_job_state(cancel_job_id, "CANCELLED")
+                self.assertIn(cancel_job_id, cancel_status_output)
+
+                time.sleep(3)
+                row_count_after_cancel = self._query_clickhouse(
+                    f"SELECT count() FROM data_{model_id} FORMAT TabSeparated"
+                )
+                self.assertEqual(row_count_after_cancel, ["3"])
+
+                final_job_list = self._run_cli("job", "list")
+                self.assertIn(valid_job_id, final_job_list)
+                self.assertIn(partial_job_id, final_job_list)
+                self.assertIn(cancel_job_id, final_job_list)
+                self.assertIn("CANCELLED", final_job_list)
+                self.assertIn("PARTIAL_SUCCESS", final_job_list)
+                self.assertIn("SUCCESS", final_job_list)
+
+                delete_output = self._run_cli("model", "delete", model_id)
+                self.assertEqual(delete_output, "204")
+                model_id = None
+
+                remaining_models = self._literal_output("model", "list")
+                self.assertNotIn(model_name, {model["name"] for model in remaining_models})
+            finally:
+                if model_id:
+                    try:
+                        requests.delete(f"{API_URL}/models/{model_id}", timeout=5)
+                    except Exception:
+                        pass

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,71 @@
+import unittest
+from unittest import mock
+
+from batch import worker
+
+
+class WorkerTests(unittest.TestCase):
+    def test_validate_rows_accepts_supported_types(self):
+        rows = [
+            {
+                "event_id": "1",
+                "timestamp": "1716045542",
+                "amount": "12.5",
+            }
+        ]
+        schema = {
+            "event_id": "String",
+            "timestamp": "UInt32",
+            "amount": "Float64",
+        }
+
+        valid_rows, rejected_rows, invalid_row_count = worker._validate_rows(rows, schema)
+
+        self.assertEqual(
+            valid_rows,
+            [{"event_id": "1", "timestamp": 1716045542, "amount": 12.5}],
+        )
+        self.assertEqual(rejected_rows, [])
+        self.assertEqual(invalid_row_count, 0)
+
+    def test_validate_rows_rejects_invalid_values(self):
+        rows = [
+            {
+                "event_id": "1",
+                "timestamp": "bad",
+                "amount": "",
+            }
+        ]
+        schema = {
+            "event_id": "String",
+            "timestamp": "UInt32",
+            "amount": "Float64",
+        }
+
+        valid_rows, rejected_rows, invalid_row_count = worker._validate_rows(rows, schema)
+
+        self.assertEqual(valid_rows, [])
+        self.assertEqual(invalid_row_count, 1)
+        self.assertEqual({row["column"] for row in rejected_rows}, {"timestamp", "amount"})
+        self.assertEqual(
+            {row["error"] for row in rejected_rows},
+            {"INVALID_UINT32", "MISSING_COLUMN"},
+        )
+
+    @mock.patch("batch.worker.requests.get")
+    def test_job_is_cancelled_returns_true_for_cancelled_job(self, mock_get):
+        mock_get.return_value.json.return_value = {"state": "CANCELLED"}
+        mock_get.return_value.raise_for_status.return_value = None
+
+        self.assertTrue(worker._job_is_cancelled("job123"))
+
+    @mock.patch("batch.worker.requests.get")
+    def test_job_is_cancelled_returns_false_for_active_job(self, mock_get):
+        mock_get.return_value.json.return_value = {"state": "SUCCESS"}
+        mock_get.return_value.raise_for_status.return_value = None
+
+        self.assertFalse(worker._job_is_cancelled("job123"))
+
+    def test_processing_delay_applies_cancellation_grace_window(self):
+        self.assertEqual(worker._processing_delay_ms(1_000, 1_100), 400)
+        self.assertEqual(worker._processing_delay_ms(1_000, 1_500), 0)


### PR DESCRIPTION
## Summary
- fix clean-checkout setup and runtime issues across the API, worker, Kafka topics, and ClickHouse integration
- harden job lifecycle handling, including cancellation semantics that prevent writes after cancel
- add unit coverage for the API and worker plus live end-to-end CLI coverage for all CLI commands
- document the updated local setup and E2E test flow

## Testing
- `.venv/bin/ruff check batch tests`
- `.venv/bin/python -m unittest discover -s tests`
- `BATCH_E2E=1 .venv/bin/python -m unittest discover -s tests`

## Validation
- rebuilt the environment from scratch
- brought the stack up with `docker-compose up --build -d`
- confirmed all services were running and ClickHouse was healthy